### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "composer-plugin-api": "1.0.0",
+        "composer-plugin-api": "^1.0.0",
         "kisma/kisma": "*",
         "dreamfactory/php-utils": "*"
     },


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.
